### PR TITLE
Support for Digest Authentication

### DIFF
--- a/extension/auth/AuthTokenExtension.js
+++ b/extension/auth/AuthTokenExtension.js
@@ -40,18 +40,25 @@ function AuthTokenExtension(editor,container) {
         var popup;
         var self = this;
 
-        this.onLogin = function(name,pwd){}
+        this.onLogin = function(name,pwd,authtype){}
 
         this.open = function(){
             popup = editor.popup.custom("Login");
 
             var name = $("<input>");
             var pwd = $("<input>").attr("type","password");
+            var radioToken = $("<input>").attr("type","radio").attr("name","authtype").attr("value","token").attr("id","rToken").attr("checked","true");
+            var radioTokenLabel = $("<label>").attr("for","rToken").text("Token Authentication");
+            var radioDigest = $("<input>").attr("type","radio").attr("name","authtype").attr("value","digest").attr("id","rDigest");
+            var radioDigestLabel = $("<label>").attr("for","rDigest").text("Digest Authentication");
             var button = $("<button></button>").text("Login").click(function(){
-                self.onLogin(name.val(),pwd.val());
+                var radioAnswer = undefined;
+                if(radioToken.is(':checked')) radioAnswer = "token";
+                else if(radioDigest.is(':checked')) radioAnswer = "digest";
+                self.onLogin(name.val(),pwd.val(),radioAnswer);
             });
 
-            popup.setContent($("<div style='text-align: center'></div>").append(name).append("<br>").append(pwd).append("<br>").append(button));
+            popup.setContent($("<div style='text-align: center'></div>").append(name).append("<br>").append(pwd).append("<br>").append(radioToken).append(radioTokenLabel).append("<br>").append(radioDigest).append(radioDigestLabel).append("<br>").append(button));
             popup.open();
         }
 
@@ -71,7 +78,7 @@ function AuthTokenExtension(editor,container) {
 
     //logout process
     function logout() {
-        editor.authentification.setAuthToken(undefined);
+        editor.authentification.setAuth(undefined, undefined, undefined);
         createLogin();
         if(graph != undefined) editor.event.fire(new Event(editor.EventCode.GRAPH.LOAD,{uri:graph.uri,title:graph.title}));
     }
@@ -82,8 +89,8 @@ function AuthTokenExtension(editor,container) {
         var popup = new Popup();
         popup.open();
 
-        function onsuccess(name, token) {
-            editor.authentification.setAuthToken(token);
+        function onsuccess(name, pwd, token) {            
+            editor.authentification.setAuth(name, pwd, token);            
             createLogout(name);
             if(graph != undefined) editor.event.fire(new Event(editor.EventCode.GRAPH.LOAD,{uri:graph.uri,title:graph.title}));
             popup.close();
@@ -95,9 +102,15 @@ function AuthTokenExtension(editor,container) {
         }
 
         //TODO this function must be replaced by a real getToken method
-        function getToken(name,pwd) {
+        function getToken(name,pwd,authtype) {
             var token = "xyzabc";
-            onsuccess(name, token);
+            if(authtype == "token") {
+                // token retrieval should be implemented here                
+            }
+            else if(authtype == "digest") {
+                token = undefined;
+            }                
+            onsuccess(name, pwd, token);
         }
 
         popup.onLogin = getToken;

--- a/js/skos-client.js
+++ b/js/skos-client.js
@@ -179,13 +179,13 @@ function SKOSClient(sparqlClient,options) {
             var datetime = currentDateTime();
             language = language&&language!='none'?"@"+language:"";
             type = type ? "^^<"+type+">" : "";
-            var query = "WITH <" + graph + "> DELETE {<" + uri + "> <" + property + "> \"" + value_old + "\"" + type + language + ";<"+ namespaces.DC_TERMS+"modified>?_mod} INSERT {<" + uri + "> <" + property + "> \"" + value_new + "\"" + type + language + ";<"+ namespaces.DC_TERMS+"modified>\""+datetime+"\"^^<http://www.w3.org/2001/XMLSchema#dateTime>.} WHERE {<" + uri + "> <" + property + "> \"" + value_old + "\"" + type + language + ".OPTIONAL {<" + uri + "><"+ namespaces.DC_TERMS+"modified>?_mod}}";
+            var query = "WITH <" + graph + "> DELETE {<" + uri + "> <" + property + "> \"" + value_old + "\"" + type + language + ";<"+ namespaces.DC_TERMS+"modified>?_mod} INSERT {<" + uri + "> <" + property + "> \"" + value_new + "\"" + type + language + ";<"+ namespaces.DC_TERMS+"modified>\""+datetime+"\"^^<http://www.w3.org/2001/XMLSchema#dateTime>.} WHERE {<" + uri + "> <" + property + "> \"" + value_old + "\"" + type + language + ". OPTIONAL {<" + uri + "><"+ namespaces.DC_TERMS+"modified>?_mod}}";
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.update(query, onsuccess, onfailure);
         },
         uri : function(graph,uri,property,value_old,value_new,onsuccess, onfailure) {
             var datetime = currentDateTime();
-            var query = "WITH <" + graph + "> DELETE {<" + uri + "> <" + property + "> <" + value_old + ">;<"+ namespaces.DC_TERMS+"modified>?_mod} INSERT {<" + uri + "> <" + property + "> <" + value_new + ">;<"+ namespaces.DC_TERMS+"modified>\""+datetime+"\"^^<http://www.w3.org/2001/XMLSchema#dateTime>.} WHERE {<" + uri + "> <" + property + "> <" + value_old + ">.OPTIONAL {<" + uri + "><"+ namespaces.DC_TERMS+"modified>?_mod}}";
+            var query = "WITH <" + graph + "> DELETE {<" + uri + "> <" + property + "> <" + value_old + ">;<"+ namespaces.DC_TERMS+"modified>?_mod} INSERT {<" + uri + "> <" + property + "> <" + value_new + ">;<"+ namespaces.DC_TERMS+"modified>\""+datetime+"\"^^<http://www.w3.org/2001/XMLSchema#dateTime>.} WHERE {<" + uri + "> <" + property + "> <" + value_old + ">. OPTIONAL {<" + uri + "><"+ namespaces.DC_TERMS+"modified>?_mod}}";
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.update(query, onsuccess, onfailure);
         }
@@ -224,7 +224,7 @@ function SKOSClient(sparqlClient,options) {
             sparqlClient.update(query, onsuccess, onfailure);
         },
         concept : function(graph,uri,onsuccess, onfailure) {
-            var query = "WITH <" + graph + "> DELETE {<"+uri+">?x?z.?a?b<"+uri+">} WHERE {<"+uri+">?x?z.OPTIONAL{?a?b<"+uri+">}}";
+            var query = "WITH <" + graph + "> DELETE {<"+uri+">?x?z.?a?b<"+uri+">} WHERE {<"+uri+">?x?z. OPTIONAL{?a?b<"+uri+">}}";
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.update(query, onsuccess, onfailure);
         },
@@ -281,19 +281,19 @@ function SKOSClient(sparqlClient,options) {
         },
         schemes : function(graph, onsuccess, onfailure) {
             var language = OPTIONS.LANGUAGE=='none'?"":OPTIONS.LANGUAGE;
-            var query = "SELECT DISTINCT ?uri ?title ?children {GRAPH <" + graph + "> {?uri a <" + namespaces.SKOS + "ConceptScheme>.OPTIONAL { ?uri <" + OPTIONS.LABEL_SCHEME + "> ?title. FILTER (lang(?title) = '" + language + "') }BIND ( EXISTS { ?uri <" + namespaces.SKOS + "hasTopConcept> ?_top } AS ?children )}}";
+            var query = "SELECT DISTINCT ?uri ?title ?children {GRAPH <" + graph + "> {?uri a <" + namespaces.SKOS + "ConceptScheme>. OPTIONAL { ?uri <" + OPTIONS.LABEL_SCHEME + "> ?title. FILTER (lang(?title) = '" + language + "') }BIND ( EXISTS { ?uri <" + namespaces.SKOS + "hasTopConcept> ?_top } AS ?children )}}";
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.select(query, onsuccess, onfailure)
         },
         top_concepts : function(graph, scheme, onsuccess, onfailure) {
             var language = OPTIONS.LANGUAGE=='none'?"":OPTIONS.LANGUAGE;
-            var query = "SELECT DISTINCT ?uri ?title ?children {GRAPH <" + graph + ">  {<" + scheme + "> <" + namespaces.SKOS + "hasTopConcept> ?uri.OPTIONAL { ?uri <" + namespaces.SKOS + "prefLabel> ?title . FILTER (lang(?title) = '" + language + "') }BIND ( EXISTS { ?uri <" + namespaces.SKOS + "narrower> ?_narrow } AS ?children )}}";
+            var query = "SELECT DISTINCT ?uri ?title ?children {GRAPH <" + graph + ">  {<" + scheme + "> <" + namespaces.SKOS + "hasTopConcept> ?uri. OPTIONAL { ?uri <" + namespaces.SKOS + "prefLabel> ?title . FILTER (lang(?title) = '" + language + "') }BIND ( EXISTS { ?uri <" + namespaces.SKOS + "narrower> ?_narrow } AS ?children )}}";
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.select(query, onsuccess, onfailure)
         },
         narrower : function(graph, concept, onsuccess, onfailure) {
             var language = OPTIONS.LANGUAGE=='none'?"":OPTIONS.LANGUAGE;
-            var query = "SELECT DISTINCT ?uri ?title ?children {GRAPH <" + graph + "> {<" + concept + "> <" + namespaces.SKOS + "narrower> ?uri.OPTIONAL { ?uri <" + namespaces.SKOS + "prefLabel> ?title . FILTER (lang(?title) = '" + language + "') }BIND ( EXISTS { ?uri <" + namespaces.SKOS + "narrower> ?_narrow } AS ?children )}}";
+            var query = "SELECT DISTINCT ?uri ?title ?children {GRAPH <" + graph + "> {<" + concept + "> <" + namespaces.SKOS + "narrower> ?uri. OPTIONAL { ?uri <" + namespaces.SKOS + "prefLabel> ?title . FILTER (lang(?title) = '" + language + "') }BIND ( EXISTS { ?uri <" + namespaces.SKOS + "narrower> ?_narrow } AS ?children )}}";
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.select(query, onsuccess, onfailure)
         },
@@ -310,7 +310,7 @@ function SKOSClient(sparqlClient,options) {
         },
         freeConcepts : function(graph,onsuccess, onfailure) {
             var language = OPTIONS.LANGUAGE=='none'?"":OPTIONS.LANGUAGE;
-            var query = "SELECT ?uri ?title ?children WHERE {GRAPH <"+graph+"> {?uri <"+namespaces.RDF+"type> <"+namespaces.SKOS+"Concept>. FILTER NOT EXISTS {?_sub1 <"+namespaces.SKOS+"narrower> ?uri}. FILTER NOT EXISTS {?_sub2 <"+namespaces.SKOS+"hasTopConcept> ?uri}.OPTIONAL{ ?uri <"+namespaces.SKOS+"prefLabel> ?title.FILTER(lang(?title)='"+language+"')}BIND(EXISTS {?uri <"+namespaces.SKOS+"narrower> ?_narrow} AS ?children)}}"
+            var query = "SELECT ?uri ?title ?children WHERE {GRAPH <"+graph+"> {?uri <"+namespaces.RDF+"type> <"+namespaces.SKOS+"Concept>. FILTER NOT EXISTS {?_sub1 <"+namespaces.SKOS+"narrower> ?uri}. FILTER NOT EXISTS {?_sub2 <"+namespaces.SKOS+"hasTopConcept> ?uri}. OPTIONAL{ ?uri <"+namespaces.SKOS+"prefLabel> ?title.FILTER(lang(?title)='"+language+"')}BIND(EXISTS {?uri <"+namespaces.SKOS+"narrower> ?_narrow} AS ?children)}}"
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.select(query, onsuccess, onfailure);
         },
@@ -329,7 +329,7 @@ function SKOSClient(sparqlClient,options) {
     this.search = {
         suggestion : function(graph, text, limit, case_sensitive, onsuccess, onfailure) {
             var language = OPTIONS.LANGUAGE=='none'?"":OPTIONS.LANGUAGE;
-            var query = "Select DISTINCT ?uri ?text ?scheme {GRAPH<" + graph + "> {?uri <" + namespaces.RDF + "type> <" + namespaces.SKOS + "Concept>;<" + namespaces.SKOS + "prefLabel> ?text.OPTIONAL{?uri <" + namespaces.SKOS + "altLabel> ?alt_text.}OPTIONAL{?uri <"+namespaces.SKOS+"inScheme> ?scheme_uri. ?scheme_uri <"+namespaces.RDFS+"label> ?scheme.FILTER (lang(?scheme) = '" + language + "') }FILTER (regex(str(?text), \"" + text + "\" " + (case_sensitive ? "" : ",\"i\"") + ")||regex(str(?alt_text), \"" + text + "\" " + (case_sensitive ? "" : ",\"i\"") + ")).FILTER (lang(?text) = '" + language + "')}} LIMIT " + limit;
+            var query = "Select DISTINCT ?uri ?text ?scheme {GRAPH<" + graph + "> {?uri <" + namespaces.RDF + "type> <" + namespaces.SKOS + "Concept>;<" + namespaces.SKOS + "prefLabel> ?text. OPTIONAL{?uri <" + namespaces.SKOS + "altLabel> ?alt_text.}OPTIONAL{?uri <"+namespaces.SKOS+"inScheme> ?scheme_uri. ?scheme_uri <"+namespaces.RDFS+"label> ?scheme.FILTER (lang(?scheme) = '" + language + "') }FILTER (regex(str(?text), \"" + text + "\" " + (case_sensitive ? "" : ",\"i\"") + ")||regex(str(?alt_text), \"" + text + "\" " + (case_sensitive ? "" : ",\"i\"") + ")).FILTER (lang(?text) = '" + language + "')}} LIMIT " + limit;
             if(OPTIONS.DEBUG)console.debug(query);
             sparqlClient.select(query, onsuccess, onfailure);
         }

--- a/js/sparql-client.js
+++ b/js/sparql-client.js
@@ -7,8 +7,8 @@ function SparqlClient(endpointSelect, endpointUpdate) {
 
     var HTTP = new HTTP_Client();
 
-    this.setAuthToken = function(token) {
-        HTTP.setAuthToken(token);
+    this.setAuth = function(user, pass, token) {
+        HTTP.setAuth(user, pass, token);
     }
 
     /**
@@ -77,6 +77,8 @@ function SparqlClient(endpointSelect, endpointUpdate) {
 function HTTP_Client() {
 
     var auth_token = undefined;
+    var auth_user = undefined;
+    var auth_pass = undefined;
 
     function createRequest() {
         var request = null;
@@ -116,10 +118,11 @@ function HTTP_Client() {
                     throw "Status:" + request.status + ",Text:" + request.responseText;
                 }
             }
-        };
-        request.open(method, _url, true);
-        if (method == "PUT" || method == "POST")request.setRequestHeader("Content-Type", mimetype);
-        if (method == "GET")request.setRequestHeader("Accept", mimetype);
+        };        
+        if (auth_token == undefined) request.open(method, _url, true, auth_user, auth_pass);
+        else request.open(method, _url, true);
+        if (method == "PUT" || method == "POST") request.setRequestHeader("Content-Type", mimetype);
+        if (method == "GET") request.setRequestHeader("Accept", mimetype);
         request.send(data);
     }
 
@@ -139,7 +142,9 @@ function HTTP_Client() {
         doRequest("DELETE", path, queryParams, data, mimetype, callbacks);
     }
 
-    this.setAuthToken = function(token) {
+    this.setAuth = function(user, pass, token) {
+        auth_user = user;
+        auth_pass = pass;
         auth_token = token;
     }
 }

--- a/skos.js
+++ b/skos.js
@@ -268,8 +268,8 @@ function SKOSEditor(options) {
             init();
         },
         authentification: {
-            setAuthToken : function(token) {
-                client.setAuthToken(token);
+            setAuth : function(user, pass, token) {
+                client.setAuth(user, pass, token);
             }
         }
     }


### PR DESCRIPTION
Added support for Digest Authentication (username / password). The user can now choose between a Token Authentication (default) and a Digest Authentication, when logging in.

This was necessary for integrating the SKOSjs app with a Virtuoso instance. If SKOSjs is to be used against a Virtuoso instance, you need to use Digest Authentication, against a /sparql-auth endpoint.

A running instance can be tested here: http://fusepool.openlinksw.com/DAV/SKOSjs/index.html. Ping me for the password.
