### PR TITLE
Virtuoso boolean support

### DIFF
--- a/skos.js
+++ b/skos.js
@@ -813,7 +813,7 @@ function SKOSEditor(options) {
             var current_uri = data.uri.value;
             var loadChildren = type=='scheme'? skos.list.top_concepts : skos.list.narrower;
             var _child_type = type=='scheme'?"top-concept":"concept";
-            if(data.children.value.bool()) {
+            if(data.children.value.bool() || data.children.value == 1) {
                 _more.addClass('plus');
                 _more.click(function(){
                     if(_more.hasClass('plus')){


### PR DESCRIPTION
Virtuoso uses "1/0" as boolean values, and SKOSjs recognized only "true/false" as booleans. Added a small change to SKOSjs for compatibility with Virtuoso's "1/0" boolean approach.
